### PR TITLE
[BD-55] feat: 로그인 기능 구현

### DIFF
--- a/api/src/main/java/com/example/api/domain/user/controller/AuthController.java
+++ b/api/src/main/java/com/example/api/domain/user/controller/AuthController.java
@@ -1,13 +1,16 @@
 package com.example.api.domain.user.controller;
 
+import com.example.api.domain.user.dto.requestDto.LoginRequestDto;
 import com.example.api.domain.user.dto.requestDto.SignupRequestDto;
 import com.example.api.domain.user.dto.responseDto.SignupResponseDto;
+import com.example.api.domain.user.dto.responseDto.TokenResponseDto;
 import com.example.api.domain.user.service.AuthService;
 import com.example.api.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,5 +33,14 @@ public class AuthController {
                 "CREATED",
                 authService.signup(requestDto)
             ));
+    }
+
+    @GetMapping("/login")
+    public ResponseEntity<ApiResponse<TokenResponseDto>> login(
+        @Valid @RequestBody LoginRequestDto requestDto
+    ) {
+        return ResponseEntity.ok(ApiResponse.ok(
+            authService.login(requestDto)
+        ));
     }
 }

--- a/api/src/main/java/com/example/api/domain/user/dto/requestDto/LoginRequestDto.java
+++ b/api/src/main/java/com/example/api/domain/user/dto/requestDto/LoginRequestDto.java
@@ -1,0 +1,16 @@
+package com.example.api.domain.user.dto.requestDto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequestDto {
+
+    @NotBlank(message = "아이디는 필수 입력값입니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    private String password;
+}

--- a/api/src/main/java/com/example/api/domain/user/dto/responseDto/SignupResponseDto.java
+++ b/api/src/main/java/com/example/api/domain/user/dto/responseDto/SignupResponseDto.java
@@ -23,7 +23,7 @@ public class SignupResponseDto {
     public static SignupResponseDto from(User entity) {
         return SignupResponseDto.builder()
             .id(entity.getId())
-            .username(entity.getUsername())
+            .username(entity.getNickname())
             .email(entity.getEmail())
             .phoneNumber(entity.getPhoneNumber())
             .createdAt(entity.getCreatedAt())

--- a/api/src/main/java/com/example/api/domain/user/dto/responseDto/TokenResponseDto.java
+++ b/api/src/main/java/com/example/api/domain/user/dto/responseDto/TokenResponseDto.java
@@ -1,0 +1,11 @@
+package com.example.api.domain.user.dto.responseDto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenResponseDto {
+
+    private final String token;
+}

--- a/api/src/main/java/com/example/api/domain/user/entity/User.java
+++ b/api/src/main/java/com/example/api/domain/user/entity/User.java
@@ -32,9 +32,7 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     @Column(unique = true)
     private String email;
-
     private String password;
-
     private String phoneNumber;
 
     @Builder
@@ -45,6 +43,14 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.phoneNumber = phoneNumber;
     }
 
+    public String getNickname() {
+        return username;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
 
     // roll을 통한 권한을 설정하지 않았기 때문에 empty
     @Override

--- a/api/src/main/java/com/example/api/domain/user/repository/UserRepository.java
+++ b/api/src/main/java/com/example/api/domain/user/repository/UserRepository.java
@@ -1,9 +1,12 @@
 package com.example.api.domain.user.repository;
 
 import com.example.api.domain.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
 
     boolean existsByUsername(String username);
 

--- a/api/src/main/java/com/example/api/domain/user/service/AuthService.java
+++ b/api/src/main/java/com/example/api/domain/user/service/AuthService.java
@@ -1,10 +1,17 @@
 package com.example.api.domain.user.service;
 
+import com.example.api.domain.user.dto.requestDto.LoginRequestDto;
 import com.example.api.domain.user.dto.requestDto.SignupRequestDto;
 import com.example.api.domain.user.dto.responseDto.SignupResponseDto;
+import com.example.api.domain.user.dto.responseDto.TokenResponseDto;
 import com.example.api.domain.user.entity.User;
 import com.example.api.domain.user.repository.UserRepository;
+import com.example.api.global.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
@@ -30,5 +40,19 @@ public class AuthService {
         User user = requestDto.toEntity(encodedPassword);
 
         return SignupResponseDto.from(userRepository.save(user));
+    }
+
+
+    public TokenResponseDto login(LoginRequestDto requestDto) {
+        Authentication authentication = authenticationManager.authenticate(
+            new UsernamePasswordAuthenticationToken(
+                requestDto.getEmail(),
+                requestDto.getPassword()
+            )
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        String jwt = jwtTokenProvider.createToken(authentication);
+
+        return new TokenResponseDto(jwt);
     }
 }

--- a/api/src/main/java/com/example/api/global/config/SecurityConfig.java
+++ b/api/src/main/java/com/example/api/global/config/SecurityConfig.java
@@ -1,17 +1,31 @@
 package com.example.api.global.config;
 
+import com.example.api.global.security.handler.CustomAccessDeniedHandler;
+import com.example.api.global.security.handler.JwtAuthenticationEntryPoint;
+import com.example.api.global.security.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -28,8 +42,21 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/auth/**").permitAll()
                 .anyRequest().authenticated()
-            );
+
+            )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+        UserDetailsService userDetailsService,
+        PasswordEncoder passwordEncoder) {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder);
+
+        return new ProviderManager(authProvider);
     }
 }

--- a/api/src/main/java/com/example/api/global/security/handler/CustomAccessDeniedHandler.java
+++ b/api/src/main/java/com/example/api/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,28 @@
+package com.example.api.global.security.handler;
+
+import com.example.api.global.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request,
+        HttpServletResponse response,
+        AccessDeniedException accessDeniedException) throws IOException {
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+        ApiResponse<Void> errorResponse = ApiResponse.error("접근 권한이 없습니다.", "FORBIDDEN");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/api/src/main/java/com/example/api/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/api/src/main/java/com/example/api/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,28 @@
+package com.example.api.global.security.handler;
+
+import com.example.api.global.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request,
+        HttpServletResponse response,
+        AuthenticationException authException) throws IOException {
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ApiResponse<Void> errorResponse = ApiResponse.error("인증이 필요합니다.", "UNAUTHORIZED");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/api/src/main/java/com/example/api/global/security/jwt/JwtAuthenticationFilter.java
+++ b/api/src/main/java/com/example/api/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package com.example.api.global.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+        String token = getTokenFromRequest(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            String email = jwtTokenProvider.getEmail(token);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+            Authentication authentication =
+                new UsernamePasswordAuthenticationToken(
+                    userDetails,
+                    null,
+                    userDetails.getAuthorities()
+                );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+}

--- a/api/src/main/java/com/example/api/global/security/jwt/JwtTokenProvider.java
+++ b/api/src/main/java/com/example/api/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,62 @@
+package com.example.api.global.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.util.Base64;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    private final long tokenValidityInMilliseconds = 1000L * 60 * 60; // 1시간
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @PostConstruct
+    protected void init() {
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    public String createToken(Authentication authentication) {
+        String email = authentication.getName();
+        Claims claims = Jwts.claims().setSubject(email);
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + tokenValidityInMilliseconds);
+
+        return Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(validity)
+            .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public String getEmail(String token) {
+        return Jwts.parserBuilder()
+            .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+            .build()
+            .parseClaimsJws(token)
+            .getBody()
+            .getSubject();
+    }
+}

--- a/api/src/main/java/com/example/api/global/security/service/CustomUserDetailsService.java
+++ b/api/src/main/java/com/example/api/global/security/service/CustomUserDetailsService.java
@@ -1,0 +1,21 @@
+package com.example.api.global.security.service;
+
+import com.example.api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmail(email)
+            .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -11,3 +11,5 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.properties.hibernate.use_sql_comments=true
 logging.level.org.springframework.web=DEBUG
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG
+# jwt 시큰
+jwt.secret=${jwt_secret}


### PR DESCRIPTION
- AuthController 수정 :  /auth/login 요청에 대한 처리
- LoginRequstDto 생성 및 구현 : 이메일, 비밀번호 입력받음
- AuthService 수정 : 인증 객체 생성(Authentication), JWT 토큰 생성 로직 구현
- CustomUserDetailsService 생성 및 구현 : DB에 해당 유저가 존재하는지 조회
- UserRepository 수정 : DB에 해당 유저가 존재하는지 조회하는 메서드 추가
- JwtTokenProvider 생성 및 구현 : JWT 토큰 생성 및 유효성 검증 메서드 구현
- .env 파일 수정 : JWT secret key 환경 변수 설정
- application.properties 파일 수정 : JWT secret key 환경 변수 사용
- TokenResponseDto 생성 및 구현 : 생성된 JWT 토큰 응답
- JwtAuthenticationFilter 생성 및 구현 : 요청 헤더에서 JWT 토큰을 추출 및 유효성 검증하여 유저의 인증 정보를 확인하고, 이를 SecurityContext에 저장
- User 엔티티 수정 : 이메일은 getUsername에서 반환, 닉네임은 getNickname으로 반환하도록 수정
   - JwtTokenProvider에서 getName()을 사용하기 때문
- CustomAccessDeniedHandler 생성 및 구현 : 권한이 없는 리소스에 접근할 때 발생하는 `accessDeniedException`을 처리
- JwtAuthenticationEntryPoint 생성 및 구현 : 인증되지 않은 사용자가 보호된 리소스에 접근할 때 발생하는 `authException`을 처리

## 🔍 관련 Jira 이슈

- BD-55


## 📌 작업 내용

- 로그인 API 구현


## ✅ 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트


## 🗂 참고 사항
