### PR TITLE
[BD-75] feat: 버킷 삭제 API 구현

### DIFF
--- a/api/src/main/java/com/example/api/domain/bucket/controller/BucketController.java
+++ b/api/src/main/java/com/example/api/domain/bucket/controller/BucketController.java
@@ -10,6 +10,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -56,6 +57,19 @@ public class BucketController {
             "버킷이 수정되었습니다.",
             "OK",
             bucketService.updateBucket(id, requestDto, user)
+        ));
+    }
+
+    // 버킷 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteBucket(@PathVariable Long id,
+        @AuthenticationPrincipal User user) {
+        bucketService.deleteBucket(id, user);
+
+        return ResponseEntity.ok(ApiResponse.ok(
+            "버킷이 삭제되었습니다.",
+            "NO CONTENT",
+            null
         ));
     }
 }

--- a/api/src/main/java/com/example/api/domain/bucket/service/BucketService.java
+++ b/api/src/main/java/com/example/api/domain/bucket/service/BucketService.java
@@ -41,4 +41,13 @@ public class BucketService {
 
         return BucketUpdateResponseDto.from(bucket);
     }
+
+    // 버킷 삭제
+    @Transactional
+    public void deleteBucket(Long id, User user) {
+        Bucket bucket = bucketRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("해당 버킷을 찾을 수 없습니다."));
+
+        bucketRepository.delete(bucket);
+    }
 }


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- BD-75


## 📌 작업 내용

- `BucketController` 수정 : /buckets/{id} DELETE 요청에 대한 처리
- `BucketService` 수정 : DB에서 id가 일치하는 버킷을 조회한 후 삭제


## ✅ 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트


## 🗂 참고 사항