### PR TITLE
[BD-89] feat: back 버킷 이미지 s3 구현

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -38,10 +38,13 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-//    jwt 의존성
+    // jwt 의존성
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // AWS S3 의존성
+    implementation 'software.amazon.awssdk:s3:2.20.12'
 }
 
 tasks.named('test') {

--- a/api/src/main/java/com/example/api/domain/bucket/controller/BucketController.java
+++ b/api/src/main/java/com/example/api/domain/bucket/controller/BucketController.java
@@ -6,7 +6,6 @@ import com.example.api.domain.bucket.dto.responseDto.BucketUpdateResponseDto;
 import com.example.api.domain.bucket.service.BucketService;
 import com.example.api.domain.user.entity.User;
 import com.example.api.global.response.ApiResponse;
-import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,9 +15,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -49,11 +49,29 @@ public class BucketController {
         ));
     }
 
+//    // 버킷 수정
+//    @PatchMapping("/{id}")
+//    public ResponseEntity<ApiResponse<BucketUpdateResponseDto>> updateBucket(@PathVariable Long id,
+//        @Valid @RequestBody BucketRequestDto requestDto,
+//        @AuthenticationPrincipal User user) {
+//        return ResponseEntity.ok(ApiResponse.ok(
+//            "버킷이 수정되었습니다.",
+//            "OK",
+//            bucketService.updateBucket(id, requestDto, user)
+//        ));
+//    }
+
     // 버킷 수정
     @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<BucketUpdateResponseDto>> updateBucket(@PathVariable Long id,
-        @Valid @RequestBody BucketRequestDto requestDto,
+        @RequestPart("title") String title, @RequestPart("file") MultipartFile file,
         @AuthenticationPrincipal User user) {
+
+        BucketRequestDto requestDto = BucketRequestDto.builder()
+            .title(title)
+            .file(file)
+            .build();
+
         return ResponseEntity.ok(ApiResponse.ok(
             "버킷이 수정되었습니다.",
             "OK",

--- a/api/src/main/java/com/example/api/domain/bucket/dto/requestDto/BucketRequestDto.java
+++ b/api/src/main/java/com/example/api/domain/bucket/dto/requestDto/BucketRequestDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Builder
@@ -16,5 +17,5 @@ public class BucketRequestDto {
     @NotBlank(message = "제목은 필수 입력값입니다.")
     @Length(max = 20, message = "제목은 20글자 이내로 입력해주세요.")
     private String title;
-//    private MultipartFile image;
+    private MultipartFile file;
 }

--- a/api/src/main/java/com/example/api/domain/bucket/dto/responseDto/BucketUpdateResponseDto.java
+++ b/api/src/main/java/com/example/api/domain/bucket/dto/responseDto/BucketUpdateResponseDto.java
@@ -12,6 +12,7 @@ public class BucketUpdateResponseDto {
     private final Long id;
     private final String title;
     private final String image_path;
+    private final String originalFileName;
     private final LocalDateTime created_at;
     private final LocalDateTime updated_at;
 
@@ -20,6 +21,7 @@ public class BucketUpdateResponseDto {
             .id(entity.getId())
             .title(entity.getTitle())
             .image_path(entity.getImage_path())
+            .originalFileName(entity.getOriginalFileName())
             .created_at(entity.getCreatedAt())
             .updated_at(entity.getUpdatedAt())
             .build();

--- a/api/src/main/java/com/example/api/domain/bucket/entity/Bucket.java
+++ b/api/src/main/java/com/example/api/domain/bucket/entity/Bucket.java
@@ -30,9 +30,24 @@ public class Bucket extends BaseTimeEntity {
     @Column(length = 20)
     private String title;
     private LocalDateTime deadline;
-    private String image_path;
     @Column(nullable = false)
     private boolean is_completed;
+
+    // S3 객체의 접근 URL
+    // AWS S3 버킷 객체의 URL
+    @Column(nullable = true)
+    private String image_path;
+
+    // S3 객체의 키(식별자)
+    // 버킷 내 객체를 구분하기 위해 필요하다.
+    // 객체 삭제에 활용되는 필드
+    @Column(nullable = true)
+    private String s3Key;
+
+    // 업로드 파일의 원본 파일명
+    // 화면 출력용
+    @Column(nullable = true)
+    private String originalFileName;
 
     @Column(nullable = false)
     private int todo_all;
@@ -43,16 +58,6 @@ public class Bucket extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-//    @Builder
-//    public Bucket(String title, String image_path, boolean is_completed, Integer todo_all,
-//        Integer todo_completed) {
-//        this.title = title;
-//        this.image_path = image_path;
-//        this.is_completed = is_completed;
-//        this.todo_all = todo_all;
-//        this.todo_completed = todo_completed;
-//    }
-
     @Builder
     public Bucket(String title, String image_path, User user) {
         this.title = title;
@@ -60,8 +65,20 @@ public class Bucket extends BaseTimeEntity {
         this.user = user;
     }
 
-    public Bucket update(BucketRequestDto requestDto) {
+    @Builder
+    public Bucket(String title, String image_path, String s3Key, String originalFileName,
+        User user) {
+        this.title = title;
+        this.image_path = image_path;
+        this.s3Key = s3Key;
+        this.originalFileName = originalFileName;
+        this.user = user;
+    }
+
+    public Bucket update(BucketRequestDto requestDto, String image_path) {
         this.title = requestDto.getTitle();
+        this.image_path = image_path;
+        this.originalFileName = requestDto.getFile().getOriginalFilename();
         return this;
     }
 }

--- a/api/src/main/java/com/example/api/domain/bucket/entity/Bucket.java
+++ b/api/src/main/java/com/example/api/domain/bucket/entity/Bucket.java
@@ -75,9 +75,10 @@ public class Bucket extends BaseTimeEntity {
         this.user = user;
     }
 
-    public Bucket update(BucketRequestDto requestDto, String image_path) {
+    public Bucket update(BucketRequestDto requestDto, String image_path, String s3Key) {
         this.title = requestDto.getTitle();
         this.image_path = image_path;
+        this.s3Key = s3Key;
         this.originalFileName = requestDto.getFile().getOriginalFilename();
         return this;
     }

--- a/api/src/main/java/com/example/api/domain/bucket/service/BucketService.java
+++ b/api/src/main/java/com/example/api/domain/bucket/service/BucketService.java
@@ -37,6 +37,15 @@ public class BucketService {
     // 버킷 수정
     @Transactional
     public BucketUpdateResponseDto updateBucket(Long id, BucketRequestDto requestDto, User user) {
+        // 수정할 버킷 조회
+        Bucket bucket = bucketRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("해당 버킷을 찾을 수 없습니다."));
+
+        // 기존 이미지 삭제
+        if (bucket.getS3Key() != null) {
+            s3Service.deleteFile(bucket.getS3Key());
+        }
+
         // S3 파일 업로드
         // S3Service uploadFile() 호출
         Map<String, String> uploadResult = s3Service.uploadFile(requestDto.getFile());
@@ -44,12 +53,8 @@ public class BucketService {
         String image_path = uploadResult.get("image_path");
         String s3Key = uploadResult.get("s3Key");
 
-        // 수정할 버킷 조회
-        Bucket bucket = bucketRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("해당 버킷을 찾을 수 없습니다."));
-
         // 수정된 제목, 이미지 파일을 보내서 버킷 업데이트
-        bucket.update(requestDto, image_path);
+        bucket.update(requestDto, image_path, s3Key);
 
         return BucketUpdateResponseDto.from(bucket);
     }

--- a/api/src/main/java/com/example/api/domain/bucket/service/BucketService.java
+++ b/api/src/main/java/com/example/api/domain/bucket/service/BucketService.java
@@ -7,6 +7,7 @@ import com.example.api.domain.bucket.entity.Bucket;
 import com.example.api.domain.bucket.repository.BucketRepository;
 import com.example.api.domain.user.entity.User;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class BucketService {
 
     private final BucketRepository bucketRepository;
+    private final S3Service s3Service;
 
     public List<BucketResponseDto> getBuckets(User user) {
         return bucketRepository.findAllByUserId(user.getId()).stream()
@@ -35,9 +37,19 @@ public class BucketService {
     // 버킷 수정
     @Transactional
     public BucketUpdateResponseDto updateBucket(Long id, BucketRequestDto requestDto, User user) {
+        // S3 파일 업로드
+        // S3Service uploadFile() 호출
+        Map<String, String> uploadResult = s3Service.uploadFile(requestDto.getFile());
+
+        String image_path = uploadResult.get("image_path");
+        String s3Key = uploadResult.get("s3Key");
+
+        // 수정할 버킷 조회
         Bucket bucket = bucketRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("해당 버킷을 찾을 수 없습니다."));
-        bucket.update(requestDto);
+
+        // 수정된 제목, 이미지 파일을 보내서 버킷 업데이트
+        bucket.update(requestDto, image_path);
 
         return BucketUpdateResponseDto.from(bucket);
     }

--- a/api/src/main/java/com/example/api/domain/bucket/service/S3Service.java
+++ b/api/src/main/java/com/example/api/domain/bucket/service/S3Service.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Service
@@ -58,6 +59,20 @@ public class S3Service {
             s3Client.putObject(putObjectRequest,
                 RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
         } catch (IOException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    // S3 객체(파일) 삭제
+    public void deleteFile(String s3Key) {
+        try {
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(s3Key)
+                .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+        } catch (Exception e) {
             throw new RuntimeException(e.getMessage());
         }
     }

--- a/api/src/main/java/com/example/api/domain/bucket/service/S3Service.java
+++ b/api/src/main/java/com/example/api/domain/bucket/service/S3Service.java
@@ -1,0 +1,65 @@
+package com.example.api.domain.bucket.service;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+    private final String FILE_PATH_PREFIX = "buckets/";
+    @Value("${BUCKET_NAME}")
+    private String bucketName;
+    @Value("${REGION}")
+    private String region;
+
+    // S3 파일 업로드 처리 메서드
+    // 파일을 ArticleService에서 받은 후
+    // S3 업로드 후 객체 URL(imageUrl)과 객체 키(s3Key)를 반환하는 메서드
+    public Map<String, String> uploadFile(MultipartFile file) {
+        // UUID와 조합한 s3Key 생성
+        String s3Key = FILE_PATH_PREFIX + UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+        // S3 버킷에 파일을 업로드
+        // 업로드할 file과 S3 객체 키(s3Key)를 전달
+        uploadFileToS3(s3Key, file);
+
+        String IMAGE_URL_FORMAT = "https://%s.s3.%s.amazonaws.com/%s";
+        String image_path = String.format(IMAGE_URL_FORMAT, bucketName, region, s3Key);
+        // String imageUrl = "https://" + bucketName + ".s3." + region + ".amazonaws.com/" + s3Key; 는 위의 코드와 동일
+
+        return Map.of(
+            "image_path", image_path,
+            "s3Key", s3Key
+        );
+    }
+
+    // 실질적으로 S3 버킷에 파일(객체)를 업로드하는 메서드
+    private void uploadFileToS3(String s3Key, MultipartFile file) {
+        try {
+            // S3에 요청할 객체
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(s3Key)
+                .contentType(file.getContentType())
+                .contentLength(file.getSize())
+                .build();
+
+            // S3에 파일 업로드 요청
+            s3Client.putObject(putObjectRequest,
+                RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+}
+

--- a/api/src/main/java/com/example/api/global/config/AwsS3Config.java
+++ b/api/src/main/java/com/example/api/global/config/AwsS3Config.java
@@ -1,0 +1,36 @@
+package com.example.api.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${REGION}")
+    private String REGION;
+
+    @Value("${ACCESS_KEY}")
+    private String ACCESS_KEY;
+
+    @Value("${SECRET_KEY}")
+    private String SECRET_KEY;
+
+    @Bean
+    public S3Client s3Client() {
+        // AWS 자격 증명(Credentials) 생성
+        // 액세스 키와 시크릿 키가 필요하다.
+        StaticCredentialsProvider credential = StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(ACCESS_KEY, SECRET_KEY)
+        );
+
+        return S3Client.builder()
+            .region(Region.of(REGION))
+            .credentialsProvider(credential)
+            .build();
+    }
+}


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- BD-89


## 📌 작업 내용

- `application.properties` 수정 : AWS S3 서비스 버킷과 상호작용을 위한 의존성 추가

- `AwsS3Config` 생성 및 구현 : S3 서비스에 접근하는 클라이언트 객체를 생성, REGION, ACCESS_KEY, SECRET_KEY는 환경 변수로 관리

- `Bucket` 수정 : S3 객체의 접근 URL, 객체의 키, 업로드 파일의 원본 파일명 필드 추가
- `BucketRequestDto` 생성 및 구현 : 수정할 제목과 이미지 파일을 요청받음
- `BucketUpdateResponseDto` 생성 및 구현 : 수정된 제목, 이미지 파일을 포함한 버킷 정보를 응답
- `S3Service` 생성 및 구현 : S3 파일 업로드 처리 (업로드 후 객체 url과 객체 키 반환)
- `BucketService` 수정 : 수정할 버킷을 DB에서 조회한 후 제목, 이미지 파일 정보를 업데이트
- `BucketController` 수정 : /buckets/{id} PATCH 요청에 대한 처리
    
- `Bucket` 수정 : S3 객체의 접근 URL, 객체의 키, 업로드 파일의 원본 파일명 필드 추가
- `S3Service` 수정 : S3 객체 파일을 삭제하는 로직 추가
- `BucketService` 수정 : 이미지 업로드 시 기존 이미지 삭제 처리 로직 추가


## ✅ 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트


## 🗂 참고 사항