### PR TITLE
[BD-105] feat: back 전역 예외 처리 구현

### DIFF
--- a/api/src/main/java/com/example/api/domain/bucket/service/BucketService.java
+++ b/api/src/main/java/com/example/api/domain/bucket/service/BucketService.java
@@ -6,6 +6,7 @@ import com.example.api.domain.bucket.dto.responseDto.BucketUpdateResponseDto;
 import com.example.api.domain.bucket.entity.Bucket;
 import com.example.api.domain.bucket.repository.BucketRepository;
 import com.example.api.domain.user.entity.User;
+import com.example.api.global.exception.ResourceNotFoundException;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +40,7 @@ public class BucketService {
     public BucketUpdateResponseDto updateBucket(Long id, BucketRequestDto requestDto, User user) {
         // 수정할 버킷 조회
         Bucket bucket = bucketRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("해당 버킷을 찾을 수 없습니다."));
+            .orElseThrow(() -> new ResourceNotFoundException("일치하는 버킷을 찾을 수 없습니다."));
 
         // 기존 이미지 삭제
         if (bucket.getS3Key() != null) {
@@ -63,7 +64,7 @@ public class BucketService {
     @Transactional
     public void deleteBucket(Long id, User user) {
         Bucket bucket = bucketRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("해당 버킷을 찾을 수 없습니다."));
+            .orElseThrow(() -> new ResourceNotFoundException("일치하는 버킷을 찾을 수 없습니다."));
 
         bucketRepository.delete(bucket);
     }

--- a/api/src/main/java/com/example/api/domain/user/dto/requestDto/SignupRequestDto.java
+++ b/api/src/main/java/com/example/api/domain/user/dto/requestDto/SignupRequestDto.java
@@ -25,6 +25,7 @@ public class SignupRequestDto {
 
     @NotBlank(message = "이메일은 필수 입력값입니다.")
     @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$", message = "메일 도메인에는 . 을 포함해야 합니다.")
     private String email;
 
     private String phoneNumber;

--- a/api/src/main/java/com/example/api/domain/user/service/AuthService.java
+++ b/api/src/main/java/com/example/api/domain/user/service/AuthService.java
@@ -6,6 +6,7 @@ import com.example.api.domain.user.dto.responseDto.LoginResponseDto;
 import com.example.api.domain.user.dto.responseDto.SignupResponseDto;
 import com.example.api.domain.user.entity.User;
 import com.example.api.domain.user.repository.UserRepository;
+import com.example.api.global.exception.ResourceNotFoundException;
 import com.example.api.global.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -45,6 +46,10 @@ public class AuthService {
 
     @Transactional
     public LoginResponseDto login(LoginRequestDto requestDto) {
+        if (!userRepository.existsByUsername(requestDto.getUsername())) {
+            throw new ResourceNotFoundException("일치하는 아이디를 찾을 수 없습니다.");
+        }
+
         Authentication authentication = authenticationManager.authenticate(
             new UsernamePasswordAuthenticationToken(
                 requestDto.getUsername(),
@@ -55,7 +60,7 @@ public class AuthService {
         String jwt = jwtTokenProvider.createToken(authentication);
 
         User user = userRepository.findByUsername(requestDto.getUsername())
-            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+            .orElseThrow(() -> new ResourceNotFoundException("일치하는 사용자를 찾을 수 없습니다."));
 
         return LoginResponseDto.from(user, jwt);
 //        return new TokenResponseDto.from(jwt);

--- a/api/src/main/java/com/example/api/global/exception/FileUploadException.java
+++ b/api/src/main/java/com/example/api/global/exception/FileUploadException.java
@@ -1,0 +1,12 @@
+package com.example.api.global.exception;
+
+public class FileUploadException extends RuntimeException {
+
+    public FileUploadException(String message) {
+        super(message);
+    }
+
+    public FileUploadException() {
+        super("파일 업로드 실패");
+    }
+}

--- a/api/src/main/java/com/example/api/global/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/example/api/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,81 @@
+package com.example.api.global.exception;
+
+import com.example.api.global.response.ApiResponse;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(FileUploadException.class)
+    public ResponseEntity<ApiResponse<Void>> handleFileUpload(FileUploadException ex) {
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ApiResponse.error(ex.getMessage(), "INTERNAL_SERVER_ERROR"));
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUserNotFound(ResourceNotFoundException ex) {
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(ApiResponse.error(ex.getMessage(), "NOT_FOUND"));
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNotFoundException(NoHandlerFoundException ex) {
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(ApiResponse.error(
+                "요청한 URL을 찾을 수 없습니다: " + ex.getRequestURL(),
+                "NOT_FOUND"
+            ));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Object>> handleValidationException(
+        MethodArgumentNotValidException ex
+    ) {
+        // 모든 검증 오류 수집
+        Map<String, String> errors = new HashMap<>();
+
+        ex.getBindingResult()
+            .getFieldErrors()
+            .forEach(error ->
+                errors.put(
+                    error.getField(),
+                    error.getDefaultMessage()
+                )
+            );
+
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error(
+                "입력값 검증에 실패했습니다.",
+                "INVALID_INPUT"
+            ));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(
+        HttpRequestMethodNotSupportedException ex) {
+
+        return ResponseEntity
+            .status(HttpStatus.METHOD_NOT_ALLOWED)
+            .body(ApiResponse.error("HTTP 메서드가 적절하지 않습니다.", "METHOD_NOT_ALLOWED"));
+
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGeneralException(Exception ex) {
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ApiResponse.error("서버 내부 오류가 발생했습니다.", "INTERNAL_SERVER_ERROR"));
+    }
+}

--- a/api/src/main/java/com/example/api/global/exception/ResourceNotFoundException.java
+++ b/api/src/main/java/com/example/api/global/exception/ResourceNotFoundException.java
@@ -1,0 +1,12 @@
+package com.example.api.global.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+
+    public ResourceNotFoundException() {
+        super("일치하는 데이터를 찾을 수 없습니다.");
+    }
+}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -13,3 +13,5 @@ logging.level.org.springframework.web=DEBUG
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG
 # jwt 시큰
 jwt.secret=${jwt_secret}
+# ???? ?? ? ????? ?? ??? ?? ??
+spring.web.resources.add-mappings=false


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- BD-105


## 📌 작업 내용

- commit 1
    - `application.properties` 수정 : 리소스가 없을 때 매핑해주는 에러 핸들링 관련 설정 추가

- commit 2
    - `SignupRequestDto` 수정 : 이메일에 유효성 검증 패턴 추가 (메일 도메인에는 .이 포함되어야 함)

- commit 3
    - `GlobalExceptionHandler` 생성 및 구현 : 전역적으로 예외를 처리하는 클래스로, 모든 Controller에서 발생하는 예외를 관리

- commit 4
    - `FileUploadException` 생성 및 구현 : 이미지 파일 업로드 실패에 대한 커스텀 예외 설정

- commit 5
    - `ResourceNotFoundException` 생성 및 구현 : 일치하는 데이터 조회 실패에 대한 커스텀 예외 설정
    - `BucketService` 수정 : 기존 IllegalArgumentException → ResourceNotFoundException으로 예외 발생하도록 수정

- commit 6
    - `AuthService` 수정 : 사용자가 로그인할 때 아이디를 잘못 입력하는 경우에 대한 예외 처리 추가


## ✅ 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트


## 🗂 참고 사항