### PR TITLE
[BD-126] feat: back 투두 삭제 API 구현

### DIFF
--- a/api/src/main/java/com/example/api/domain/todo/controller/TodoController.java
+++ b/api/src/main/java/com/example/api/domain/todo/controller/TodoController.java
@@ -8,6 +8,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -52,5 +53,12 @@ public class TodoController {
         TodoResponseDto updatedTodo = todoService.updateTodo(bucketId, todoId, requestDto);
         return ResponseEntity.ok(ApiResponse.ok("투두가 수정되었습니다.", "OK", updatedTodo));
 
+    }
+
+    @DeleteMapping("/{bucketId}/todos/{todoId}")
+    public ResponseEntity<ApiResponse<Void>> deleteTodo(@PathVariable Long bucketId,
+        @PathVariable Long todoId) {
+        todoService.deleteTodo(todoId);
+        return ResponseEntity.ok(ApiResponse.ok("투두가 삭제되었습니다.", "DELETED", null));
     }
 }

--- a/api/src/main/java/com/example/api/domain/todo/service/TodoService.java
+++ b/api/src/main/java/com/example/api/domain/todo/service/TodoService.java
@@ -49,4 +49,12 @@ public class TodoService {
 
         return TodoResponseDto.from(todo);
     }
+
+    @Transactional
+    public void deleteTodo(Long todoId) {
+        Todo todo = todoRepository.findById(todoId)
+            .orElseThrow(() -> new ResourceNotFoundException("투두를 찾을 수 없습니다"));
+
+        todoRepository.delete(todo);
+    }
 }


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- BD-126


## 📌 작업 내용

- `TodoController` 일반 삭제 로직 추가
- `TodoService` 일반 삭제 로직 추가


## ✅ 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트


## 🗂 참고 사항