### PR TITLE
[BD-135] feat: back 버킷 이미지 삭제 API 구현

### DIFF
--- a/api/src/main/java/com/example/api/domain/bucket/controller/BucketController.java
+++ b/api/src/main/java/com/example/api/domain/bucket/controller/BucketController.java
@@ -8,6 +8,7 @@ import com.example.api.domain.user.entity.User;
 import com.example.api.global.response.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -66,6 +67,15 @@ public class BucketController {
             "OK",
             bucketService.updateBucket(id, requestDto, user)
         ));
+    }
+
+    // 버킷 이미지 삭제
+    @DeleteMapping("/buckets/{id}/image")
+    public ResponseEntity<ApiResponse<Void>> deleteBucketImage(@PathVariable Long id) {
+        bucketService.deleteBucketImage(id);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+            .body(ApiResponse.ok("버킷 이미지가 삭제되었습니다.", "NO_CONTENT", null));
     }
 
     // 버킷 삭제

--- a/api/src/main/java/com/example/api/domain/bucket/entity/Bucket.java
+++ b/api/src/main/java/com/example/api/domain/bucket/entity/Bucket.java
@@ -74,6 +74,13 @@ public class Bucket extends BaseTimeEntity {
         this.user = user;
     }
 
+    public Bucket update(String imageUrl, String s3Key, String originalFileName) {
+        this.imageUrl = imageUrl;
+        this.s3Key = s3Key;
+        this.originalFileName = originalFileName;
+        return this;
+    }
+
     public Bucket update(String title, String imageUrl, String s3Key, String originalFileName) {
         this.title = title;
         this.imageUrl = imageUrl;

--- a/api/src/main/java/com/example/api/domain/bucket/service/BucketService.java
+++ b/api/src/main/java/com/example/api/domain/bucket/service/BucketService.java
@@ -72,6 +72,20 @@ public class BucketService {
         return BucketUpdateResponseDto.from(bucket);
     }
 
+    // 버킷 이미지 삭제
+    @Transactional
+    public void deleteBucketImage(Long id) {
+        // 이미지를 삭제할 버킷 조회
+        Bucket bucket = bucketRepository.findById(id)
+            .orElseThrow(() -> new ResourceNotFoundException("일치하는 버킷을 찾을 수 없습니다."));
+
+        // S3에서 기존 이미지 삭제
+        s3Service.deleteFile(bucket.getS3Key());
+
+        // DB에서 이미지 삭제
+        bucket.update(null, null, null);
+    }
+
     // 버킷 삭제
     @Transactional
     public void deleteBucket(Long id, User user) {


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- BD-135


## 📌 작업 내용

- `BucketController` 수정 : /api/buckets/{bucketId}/image DELETE요청에 대한 처리
- `BucketService` 수정 : 버킷에서 이미지 삭제 버튼을 클릭하면 S3에서 이미지 삭제 + DB에서 이미지 삭제
- `Bucket` 수정 : 이미지 삭제에 맞게 update 로직 추가


## ✅ 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트


## 🗂 참고 사항