### PR TITLE
[BD-147] feat: back 버킷 수정 시 고정 투두 내용 수정

### DIFF
--- a/api/src/main/java/com/example/api/domain/bucket/service/BucketService.java
+++ b/api/src/main/java/com/example/api/domain/bucket/service/BucketService.java
@@ -48,6 +48,12 @@ public class BucketService {
         Bucket bucket = bucketRepository.findById(id)
             .orElseThrow(() -> new ResourceNotFoundException("일치하는 버킷을 찾을 수 없습니다."));
 
+        // 특정 버킷의 오름차순 정렬된 투두리스트 목록을 받아옴
+        List<Todo> todos = todoRepository.findFirstByBucketId(id);
+
+        // 버킷 수정 시 작성한 제목을 고정 투두의 내용으로 입력
+        todos.get(0).update(requestDto.getTitle() + " 완료", false);
+
         // 이미지 파일을 첨부하지 않는 경우
         if (requestDto.getFile() == null) {
             bucket.update(requestDto.getTitle(), bucket.getImageUrl(), bucket.getS3Key(), null);

--- a/api/src/main/java/com/example/api/domain/todo/repository/TodoRepository.java
+++ b/api/src/main/java/com/example/api/domain/todo/repository/TodoRepository.java
@@ -3,8 +3,14 @@ package com.example.api.domain.todo.repository;
 import com.example.api.domain.todo.entity.Todo;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     List<Todo> findByBucketId(Long id);
+
+    // 특정 버킷의 투두리스트 목록을 오름차순 정렬해서 리스트로 반환
+    @Query("SELECT t FROM Todo t WHERE t.bucket.id = :id ORDER BY t.id ASC")
+    List<Todo> findFirstByBucketId(@Param("id") Long id);
 }


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- BD-147


## 📌 작업 내용

- `TodoRepository` 수정 : 특정 버킷의 투두리스트 목록을 오름차순 정렬해서 리스트로 반환하는 JPQL 쿼리 작성
- `BucketService` 수정 : 특정 버킷의 오름차순 정렬된 투두리스트 목록을 받아와서 버킷 수정 시 작성한 제목을 고정 투두의 내용으로 입력


## ✅ 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트


## 🗂 참고 사항