### PR TITLE
[BD-148] feat: back 버킷 완료 기능 구현

### DIFF
--- a/api/src/main/java/com/example/api/domain/bucket/dto/responseDto/BucketResponseDto.java
+++ b/api/src/main/java/com/example/api/domain/bucket/dto/responseDto/BucketResponseDto.java
@@ -13,6 +13,7 @@ public class BucketResponseDto {
     private final String title;
     private final String imageUrl;
     private final boolean isCompleted;
+    private final Long fixedTodoId;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
     private final int todoAll;
@@ -24,6 +25,7 @@ public class BucketResponseDto {
             .title(entity.getTitle())
             .imageUrl(entity.getImageUrl())
             .isCompleted(entity.isCompleted())
+            .fixedTodoId(entity.getFixedTodoId())
             .createdAt(entity.getCreatedAt())
             .updatedAt(entity.getUpdatedAt())
             .todoAll(entity.getTodoAll())

--- a/api/src/main/java/com/example/api/domain/bucket/entity/Bucket.java
+++ b/api/src/main/java/com/example/api/domain/bucket/entity/Bucket.java
@@ -29,6 +29,7 @@ public class Bucket extends BaseTimeEntity {
     @Column(length = 20)
     private String title;
     private LocalDateTime deadline;
+
     @Column(nullable = false)
     private boolean isCompleted;
 
@@ -120,5 +121,10 @@ public class Bucket extends BaseTimeEntity {
     // 고정 투두 id값 저장
     public void updateFinalTodoId(Long todoId) {
         this.fixedTodoId = todoId;
+    }
+
+    // 투두 완료 여부에 따라 버킷 완료 상태 전환
+    public void bucketCompleted(boolean completed) {
+        this.isCompleted = completed;
     }
 }

--- a/api/src/main/java/com/example/api/domain/bucket/entity/Bucket.java
+++ b/api/src/main/java/com/example/api/domain/bucket/entity/Bucket.java
@@ -53,6 +53,8 @@ public class Bucket extends BaseTimeEntity {
     @Column(nullable = false)
     private int todoCompleted;
 
+    private Long fixedTodoId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -113,5 +115,10 @@ public class Bucket extends BaseTimeEntity {
         if (this.todoCompleted > 0) {
             this.todoCompleted--;
         }
+    }
+
+    // 고정 투두 id값 저장
+    public void updateFinalTodoId(Long todoId) {
+        this.fixedTodoId = todoId;
     }
 }

--- a/api/src/main/java/com/example/api/domain/bucket/service/BucketService.java
+++ b/api/src/main/java/com/example/api/domain/bucket/service/BucketService.java
@@ -38,6 +38,10 @@ public class BucketService {
         Bucket emptyBucket = bucketRepository.save(new Bucket(null, null, user));
 
         todoService.createTodo(emptyBucket.getId());
+
+        List<Todo> todos = todoRepository.findFirstByBucketId(emptyBucket.getId());
+        emptyBucket.updateFinalTodoId(todos.get(0).getId());
+
         return BucketResponseDto.from(emptyBucket);
     }
 

--- a/api/src/main/java/com/example/api/domain/todo/controller/TodoController.java
+++ b/api/src/main/java/com/example/api/domain/todo/controller/TodoController.java
@@ -1,10 +1,10 @@
 package com.example.api.domain.todo.controller;
 
 import com.example.api.domain.todo.dto.request.TodoRequestDto;
+import com.example.api.domain.todo.dto.response.TodoListResponseDto;
 import com.example.api.domain.todo.dto.response.TodoResponseDto;
 import com.example.api.domain.todo.service.TodoService;
 import com.example.api.global.response.ApiResponse;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -38,11 +38,12 @@ public class TodoController {
             );
     }
 
+    // 특정 버킷에 대한 투두 전체 조회
     @GetMapping("/{bucketId}/todos")
-    public ResponseEntity<ApiResponse<List<TodoResponseDto>>> getTodosByBucket(
+    public ResponseEntity<ApiResponse<TodoListResponseDto>> getTodosByBucket(
         @PathVariable Long bucketId) {
-        List<TodoResponseDto> todos = todoService.findTodosByBucketId(bucketId);
-        return ResponseEntity.ok(ApiResponse.ok("투두가 조회되었습니다.", "OK", todos));
+        TodoListResponseDto responseDto = todoService.findTodosByBucketId(bucketId);
+        return ResponseEntity.ok(ApiResponse.ok("투두가 조회되었습니다.", "OK", responseDto));
     }
 
     @PatchMapping("/{bucketId}/todos/{todoId}")

--- a/api/src/main/java/com/example/api/domain/todo/dto/response/TodoListResponseDto.java
+++ b/api/src/main/java/com/example/api/domain/todo/dto/response/TodoListResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.api.domain.todo.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TodoListResponseDto {
+
+    private final Long fixedTodoId;
+    private final List<TodoResponseDto> todos;
+
+    public static TodoListResponseDto from(Long fixedTodoId, List<TodoResponseDto> todos) {
+        return new TodoListResponseDto(fixedTodoId, todos);
+    }
+}

--- a/api/src/main/java/com/example/api/domain/todo/service/TodoService.java
+++ b/api/src/main/java/com/example/api/domain/todo/service/TodoService.java
@@ -3,6 +3,7 @@ package com.example.api.domain.todo.service;
 import com.example.api.domain.bucket.entity.Bucket;
 import com.example.api.domain.bucket.repository.BucketRepository;
 import com.example.api.domain.todo.dto.request.TodoRequestDto;
+import com.example.api.domain.todo.dto.response.TodoListResponseDto;
 import com.example.api.domain.todo.dto.response.TodoResponseDto;
 import com.example.api.domain.todo.entity.Todo;
 import com.example.api.domain.todo.repository.TodoRepository;
@@ -35,10 +36,16 @@ public class TodoService {
         return TodoResponseDto.from(newTodo);
     }
 
-    public List<TodoResponseDto> findTodosByBucketId(Long id) {
-        List<Todo> todos = todoRepository.findByBucketId(id);
+    public TodoListResponseDto findTodosByBucketId(Long id) {
+        Bucket bucket = bucketRepository.findById(id)
+            .orElseThrow(() -> new ResourceNotFoundException("버킷을 찾을 수 없습니다."));
 
-        return todos.stream().map(TodoResponseDto::from).toList();
+        List<Todo> todos = todoRepository.findByBucketId(id);
+        List<TodoResponseDto> todoResponseDtos = todos.stream()
+            .map(TodoResponseDto::from)
+            .toList();
+
+        return TodoListResponseDto.from(bucket.getFixedTodoId(), todoResponseDtos);
     }
 
     @Transactional

--- a/api/src/main/java/com/example/api/domain/todo/service/TodoService.java
+++ b/api/src/main/java/com/example/api/domain/todo/service/TodoService.java
@@ -58,7 +58,6 @@ public class TodoService {
         boolean wasCompleted = todo.isCompleted();
 
         todo.update(requestDto.getContent(), requestDto.isCompleted());
-        todoRepository.save(todo);
 
         Bucket bucket = todo.getBucket();
 
@@ -69,7 +68,13 @@ public class TodoService {
             } else {
                 bucket.decrementTodoCompleted();
             }
-            bucketRepository.save(bucket);
+        }
+
+        // 완료된 투두 개수와 전체 투두 개수가 일치하면 버킷을 완료 상태로 전환
+        if (bucket.getTodoAll() == bucket.getTodoCompleted()) {
+            bucket.bucketCompleted(true);
+        } else {
+            bucket.bucketCompleted(false);
         }
 
         return TodoResponseDto.from(todo);

--- a/api/src/main/java/com/example/api/global/response/ApiResponse.java
+++ b/api/src/main/java/com/example/api/global/response/ApiResponse.java
@@ -27,9 +27,6 @@ public class ApiResponse<T> {
         this.errors = errors;
     }
 
-    ;
-
-
     public static <T> ApiResponse<T> ok(T data) {
         return new ApiResponse<>(data);
     }


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- BD-148


## 📌 작업 내용

- commit 1
    - `Bucket` 수정 : fixedTodoId (고정 투두 ID) 필드 추가, 고정 투두 id값 저장 메서드 추가
    - `BucketResponseDto` 수정 : 버킷 전체 조회 시에도 고정 투두 ID를 확인할 수 있도록 응답 데이터 수정
    - `BucketService` 수정 : 고정 투두 id값 저장 로직 구현
    - `TodoController` 수정 : 투두 전체 조회 시 고정 투두 ID를 포함한 데이터 응답
    - `TodoListResponseDto` 생성 및 구현 : 고정 투두 ID와 투두 목록을 조회할 수 있도록 응답 데이터 수정
    - `TodoService` 수정 : 특정 버킷의 투두 전체 조회 시 고정 투두 ID를 포함한 데이터 응답하도록 로직 구현
    - `ApiResponse` 수정

- commit 2
    - `Bucket` 수정 : 투두 완료 여부에 따라 버킷 완료 상태 전환하는 메서드 추가
    - `TodoService` 수정 : 완료된 투두 개수와 전체 투두 개수가 일치하면 버킷을 완료 상태로 전환하는 로직 구현


## ✅ 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트


## 🗂 참고 사항