### PR TITLE
[BD-166] feat: back 리프레시 토큰 발급

### DIFF
--- a/api/src/main/java/com/example/api/domain/user/dto/response/LoginResponseDto.java
+++ b/api/src/main/java/com/example/api/domain/user/dto/response/LoginResponseDto.java
@@ -13,14 +13,16 @@ import lombok.NoArgsConstructor;
 public class LoginResponseDto {
 
     private Long id;
-    private String token;
+    private String accesstoken;
+    private String refreshtoken;
     private String username;
 
-    public static LoginResponseDto from(User entity, String token) {
+    public static LoginResponseDto from(User entity, String accesstoken, String refreshtoken) {
         return LoginResponseDto.builder()
             .id(entity.getId())
             .username(entity.getUsername())
-            .token(token)
+            .accesstoken(accesstoken)
+            .refreshtoken(refreshtoken)
             .build();
     }
 }

--- a/api/src/main/java/com/example/api/domain/user/entity/RefreshToken.java
+++ b/api/src/main/java/com/example/api/domain/user/entity/RefreshToken.java
@@ -1,0 +1,34 @@
+package com.example.api.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    public void updateToken(String newToken) {
+        this.token = newToken;
+    }
+}

--- a/api/src/main/java/com/example/api/domain/user/repository/RefreshTokenRepository.java
+++ b/api/src/main/java/com/example/api/domain/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.example.api.domain.user.repository;
+
+import com.example.api.domain.user.entity.RefreshToken;
+import com.example.api.domain.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByUser(User user);
+}

--- a/api/src/main/java/com/example/api/domain/user/service/RefreshTokenService.java
+++ b/api/src/main/java/com/example/api/domain/user/service/RefreshTokenService.java
@@ -1,0 +1,28 @@
+package com.example.api.domain.user.service;
+
+import com.example.api.domain.user.entity.RefreshToken;
+import com.example.api.domain.user.entity.User;
+import com.example.api.domain.user.repository.RefreshTokenRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public void saveOrUpdateRefreshToken(User user, String refreshToken) {
+        Optional<RefreshToken> existingToken = refreshTokenRepository.findByUser(user);
+        if (existingToken.isPresent()) {
+            existingToken.get().updateToken(refreshToken);
+        } else {
+            RefreshToken newToken = new RefreshToken(null, user, refreshToken);
+            refreshTokenRepository.save(newToken);
+        }
+    }
+}

--- a/api/src/main/java/com/example/api/global/security/jwt/JwtTokenProvider.java
+++ b/api/src/main/java/com/example/api/global/security/jwt/JwtTokenProvider.java
@@ -15,7 +15,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtTokenProvider {
 
-    private final long tokenValidityInMilliseconds = 1000L * 60 * 60 * 10; // 1시간
+    private final long accessTokenValidity = 1000L * 60; // 1분
+    private final long refreshTokenValidity = 1000L * 60 * 3; // 3분
+    //    private final long tokenValidityInMilliseconds = 1000L * 60 * 60 * 10; // 1시간
+
     @Value("${jwt.secret}")
     private String secretKey;
 
@@ -24,12 +27,27 @@ public class JwtTokenProvider {
         secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
     }
 
-    public String createToken(Authentication authentication) {
+    public String createAccessToken(Authentication authentication) {
         String username = authentication.getName();
         Claims claims = Jwts.claims().setSubject(username);
 
         Date now = new Date();
-        Date validity = new Date(now.getTime() + tokenValidityInMilliseconds);
+        Date validity = new Date(now.getTime() + accessTokenValidity);
+
+        return Jwts.builder()
+            .setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(validity)
+            .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    public String createRefreshToken(Authentication authentication) {
+        String username = authentication.getName();
+        Claims claims = Jwts.claims().setSubject(username);
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + refreshTokenValidity);
 
         return Jwts.builder()
             .setClaims(claims)


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- BD-166


## 📌 작업 내용

- `AuthService` 수정 : 로그인 시 refresh token, access token 생성하는 로직 구현
- `LoginResponseDto` 수정 : 생성된 refresh token, access token을 응답
- `JwtTokenProvider` 수정 : access token, refresh token을 생성하는 메서드 구현
- `Refresh` 생성 및 구현 : refresh token에 대한 엔티티 구현
- `RefreshTokenService` 생성 및 구현 : refresh token에 대한 저장 및 업데이트 로직 구현
- `RefreshTokenRepository` 생성 및 구현 : 해당 유저에 대한 refresh token을 조회하는 메서드 구현


## ✅ 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트


## 🗂 참고 사항