### PR TITLE
[BD-167] feat: back 로그아웃 API 구현

### DIFF
--- a/api/src/main/java/com/example/api/domain/user/controller/AuthController.java
+++ b/api/src/main/java/com/example/api/domain/user/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.example.api.domain.user.controller;
 
 import com.example.api.domain.bucket.dto.response.UsernameCheckResponseDto;
 import com.example.api.domain.user.dto.request.LoginRequestDto;
+import com.example.api.domain.user.dto.request.RefreshTokenRequestDto;
 import com.example.api.domain.user.dto.request.SignupRequestDto;
 import com.example.api.domain.user.dto.response.LoginResponseDto;
 import com.example.api.domain.user.dto.response.SignupResponseDto;
@@ -46,6 +47,16 @@ public class AuthController {
             "OK",
             authService.login(requestDto)
         ));
+    }
+
+    @PostMapping("/auth/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+        @RequestBody RefreshTokenRequestDto requestDto) {
+
+        authService.logout(requestDto);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+            .body(ApiResponse.ok("로그아웃되었습니다.", "NO_CONTENT", null));
     }
 
     // 단순히 JWT 검증을 위한 endpoint

--- a/api/src/main/java/com/example/api/domain/user/dto/request/RefreshTokenRequestDto.java
+++ b/api/src/main/java/com/example/api/domain/user/dto/request/RefreshTokenRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.api.domain.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshTokenRequestDto {
+
+    private String refreshToken;
+}

--- a/api/src/main/java/com/example/api/domain/user/repository/RefreshTokenRepository.java
+++ b/api/src/main/java/com/example/api/domain/user/repository/RefreshTokenRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByUser(User user);
+
+    Optional<RefreshToken> findByToken(String token);
 }

--- a/api/src/main/java/com/example/api/domain/user/service/AuthService.java
+++ b/api/src/main/java/com/example/api/domain/user/service/AuthService.java
@@ -1,13 +1,19 @@
 package com.example.api.domain.user.service;
 
 import com.example.api.domain.user.dto.request.LoginRequestDto;
+import com.example.api.domain.user.dto.request.RefreshTokenRequestDto;
 import com.example.api.domain.user.dto.request.SignupRequestDto;
 import com.example.api.domain.user.dto.response.LoginResponseDto;
 import com.example.api.domain.user.dto.response.SignupResponseDto;
+import com.example.api.domain.user.entity.RefreshToken;
 import com.example.api.domain.user.entity.User;
+import com.example.api.domain.user.repository.RefreshTokenRepository;
 import com.example.api.domain.user.repository.UserRepository;
 import com.example.api.global.exception.ResourceNotFoundException;
 import com.example.api.global.security.jwt.JwtTokenProvider;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -31,6 +37,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final UserDetailsService userDetailsService;
     private final RefreshTokenService refreshTokenService;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
     public SignupResponseDto signup(SignupRequestDto requestDto) {
@@ -44,7 +51,7 @@ public class AuthService {
 
         return SignupResponseDto.from(userRepository.save(user));
     }
-    
+
     @Transactional
     public LoginResponseDto login(LoginRequestDto requestDto) {
         if (!userRepository.existsByUsername(requestDto.getUsername())) {
@@ -77,6 +84,37 @@ public class AuthService {
         refreshTokenService.saveOrUpdateRefreshToken(user, refreshToken);
 
         return LoginResponseDto.from(user, accessToken, refreshToken);
+    }
+
+    @Transactional
+    public void logout(RefreshTokenRequestDto requestDto) {
+        String refreshToken = requestDto.getRefreshToken();
+
+        // 요청에 리프레시 토큰이 포함되었는지 검증
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            throw new IllegalArgumentException("요청 바디에 refresh token이 입력되지 않았습니다.");
+        }
+
+        // 리프레시 토큰이 만료되었는지 검증
+        if (jwtTokenProvider.validateTokenExpired(refreshToken)) {
+            throw new ExpiredJwtException(null, null, "refresh token이 만료되었습니다.");
+        }
+
+        // 리프레시 토큰이 유효한지(위조되지 않았는지) 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new JwtException("refresh token이 위조되었거나 유효하지 않습니다.");
+        }
+
+        // DB에 해당 리프레시 토큰이 존재하는지 검증
+        Optional<RefreshToken> storedRefreshToken = refreshTokenRepository.findByToken(
+            refreshToken);
+
+        if (storedRefreshToken.isEmpty()) {
+            throw new ResourceNotFoundException("일치하는 refresh token을 찾을 수 없습니다.");
+        }
+
+        // 리프레시 토큰에 대한 유효성이 검증되었으면 DB에서 해당 리프레시 토큰을 삭제
+        refreshTokenRepository.delete(storedRefreshToken.get());
     }
 
     public boolean checkUsername(String username) {

--- a/api/src/main/java/com/example/api/global/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/example/api/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.example.api.global.exception;
 
 import com.example.api.global.response.ApiResponse;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
@@ -66,7 +68,6 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BadCredentialsException.class)
     public ResponseEntity<ApiResponse<Void>> handleBadCredentialsException(
         BadCredentialsException ex) {
-
         return ResponseEntity
             .status(HttpStatus.UNAUTHORIZED)
             .body(ApiResponse.error(ex.getMessage(), "UNAUTHORIZED"));
@@ -75,11 +76,34 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(
         HttpRequestMethodNotSupportedException ex) {
-
         return ResponseEntity
             .status(HttpStatus.METHOD_NOT_ALLOWED)
             .body(ApiResponse.error("HTTP 메서드가 적절하지 않습니다.", "METHOD_NOT_ALLOWED"));
 
+    }
+
+    @ExceptionHandler(ExpiredJwtException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTokenExpired(
+        ExpiredJwtException ex) {
+        return ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(ApiResponse.error(ex.getMessage(), "UNAUTHORIZED"));
+    }
+
+    @ExceptionHandler(JwtException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTokenValidate(
+        JwtException ex) {
+        return ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(ApiResponse.error(ex.getMessage(), "UNAUTHORIZED"));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(
+        IllegalArgumentException ex) {
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ApiResponse.error(ex.getMessage(), "INTERNAL_SERVER_ERROR"));
     }
 
 //    @ExceptionHandler(Exception.class)

--- a/api/src/main/java/com/example/api/global/security/jwt/JwtTokenProvider.java
+++ b/api/src/main/java/com/example/api/global/security/jwt/JwtTokenProvider.java
@@ -16,8 +16,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtTokenProvider {
 
-    private final long accessTokenValidity = 1000L * 60; // 1분
-    private final long refreshTokenValidity = 1000L * 60 * 3; // 3분
+    private final long accessTokenValidity = 1000L * 60 * 60; // 1시간
+    private final long refreshTokenValidity = 1000L * 60 * 60 * 24 * 7; // 7일
     //    private final long tokenValidityInMilliseconds = 1000L * 60 * 60 * 10; // 1시간
 
     @Value("${jwt.secret}")

--- a/api/src/main/java/com/example/api/global/security/jwt/JwtTokenProvider.java
+++ b/api/src/main/java/com/example/api/global/security/jwt/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.example.api.global.security.jwt;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -57,6 +58,7 @@ public class JwtTokenProvider {
             .compact();
     }
 
+    // 토큰이 위조 여부, 유효한지 여부 검증
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder()
@@ -66,6 +68,23 @@ public class JwtTokenProvider {
             return true;
         } catch (JwtException | IllegalArgumentException e) {
             return false;
+        }
+    }
+
+    // 토큰 만료 여부를 검증
+    public boolean validateTokenExpired(String token) {
+        try {
+            Date expirationDate = Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+            return expirationDate.before(new Date());
+        } catch (ExpiredJwtException e) {
+            return true; // 만료됨
+        } catch (JwtException e) {
+            return false; // 위조된 경우는 이 메서드에서 처리하지 않음
         }
     }
 


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- BD-167


## 📌 작업 내용

- commit 1 (로그아웃 API 구현)
    - `AuthController` 수정 :  /api/auth/logout 요청에 대한 처리
    - `AuthService` 수정 : refresh token에 대한 유효성 검증을 진행한 후 검증되었으면 DB에서 해당 refresh token을 삭제
    - `RefreshTokenRepository` 수정 : 해당 refresh token을 DB에서 조회하는 메서드 추가
    - `JwtTokenProvider` 수정 : 토큰 만료 여부 검증 로직 추가
    - `RefreshTokenRequestDto` 생성 및 구현 : refresh token을 요청 바디로 받도록 구현

- commit 2 (리프레시 토큰 유효성 검증 예외 처리)
    - `GlobalExceptionHandler` 수정 : refresh token 만료되었는지, 위조되지 않았는지, 유효한지에 대한 전역 예외 처리 추가

- commit 3 (액세스 토큰, 리프레시 토큰 만료기간 수정)
    - `JwtTokenProvider` 수정 : 각각 access token 1분, refresh token 3분이던 것을 1시간, 7일로 수정


## ✅ 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트


## 🗂 참고 사항