### PR TITLE
[BD-169] feat: back 액세스 토큰 재발급

### DIFF
--- a/api/src/main/java/com/example/api/domain/user/controller/AuthController.java
+++ b/api/src/main/java/com/example/api/domain/user/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.example.api.domain.user.dto.request.RefreshTokenRequestDto;
 import com.example.api.domain.user.dto.request.SignupRequestDto;
 import com.example.api.domain.user.dto.response.LoginResponseDto;
 import com.example.api.domain.user.dto.response.SignupResponseDto;
+import com.example.api.domain.user.dto.response.TokenResponseDto;
 import com.example.api.domain.user.service.AuthService;
 import com.example.api.global.response.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
@@ -13,7 +14,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api")
@@ -24,36 +31,36 @@ public class AuthController {
 
     @PostMapping("/auth/signup")
     public ResponseEntity<ApiResponse<SignupResponseDto>> signup(
-            @Valid @RequestBody SignupRequestDto requestDto) {
+        @Valid @RequestBody SignupRequestDto requestDto) {
         return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(ApiResponse.ok(
-                        "유저가 정상적으로 생성되었습니다.",
-                        "CREATED",
-                        authService.signup(requestDto)
-                ));
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.ok(
+                "유저가 정상적으로 생성되었습니다.",
+                "CREATED",
+                authService.signup(requestDto)
+            ));
     }
 
     @PostMapping("/auth/login")
     public ResponseEntity<ApiResponse<LoginResponseDto>> login(
-            @Valid @RequestBody LoginRequestDto requestDto,
-            HttpServletResponse response
+        @Valid @RequestBody LoginRequestDto requestDto,
+        HttpServletResponse response
     ) {
         return ResponseEntity.ok(ApiResponse.ok(
-                "로그인 정상 성공",
-                "OK",
-                authService.login(requestDto, response)
+            "로그인 정상 성공",
+            "OK",
+            authService.login(requestDto, response)
         ));
     }
 
     @PostMapping("/auth/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
-            @RequestBody RefreshTokenRequestDto requestDto) {
+        @RequestBody RefreshTokenRequestDto requestDto) {
 
         authService.logout(requestDto);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
-                .body(ApiResponse.ok("로그아웃되었습니다.", "NO_CONTENT", null));
+            .body(ApiResponse.ok("로그아웃되었습니다.", "NO_CONTENT", null));
     }
 
     // 단순히 JWT 검증을 위한 endpoint
@@ -68,5 +75,14 @@ public class AuthController {
         String message = isAvailable ? "사용 가능한 아이디입니다." : "이미 사용 중인 아이디입니다.";
 
         return ResponseEntity.ok(new UsernameCheckResponseDto(message, isAvailable));
+    }
+
+    // 액세스 토큰 재발급
+    @PostMapping("/auth/reissuance")
+    public ResponseEntity<ApiResponse<TokenResponseDto>> createNewAccessToken(
+        @RequestHeader("Refresh") String refreshToken) {
+        return ResponseEntity.ok(
+            ApiResponse.ok("access token이 재발급되었습니다.", "OK",
+                authService.createNewAccessToken(refreshToken)));
     }
 }

--- a/api/src/main/java/com/example/api/domain/user/controller/AuthController.java
+++ b/api/src/main/java/com/example/api/domain/user/controller/AuthController.java
@@ -80,9 +80,9 @@ public class AuthController {
     // 액세스 토큰 재발급
     @PostMapping("/auth/reissuance")
     public ResponseEntity<ApiResponse<TokenResponseDto>> createNewAccessToken(
-        @RequestHeader("Refresh") String refreshToken) {
+        @RequestHeader("Refresh") String refreshToken, HttpServletResponse response) {
         return ResponseEntity.ok(
             ApiResponse.ok("access token이 재발급되었습니다.", "OK",
-                authService.createNewAccessToken(refreshToken)));
+                authService.createNewAccessToken(refreshToken, response)));
     }
 }

--- a/api/src/main/java/com/example/api/domain/user/dto/response/TokenResponseDto.java
+++ b/api/src/main/java/com/example/api/domain/user/dto/response/TokenResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.api.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponseDto {
+
+    private String accessToken;
+//    private String refreshToken;
+}

--- a/api/src/main/java/com/example/api/domain/user/service/AuthService.java
+++ b/api/src/main/java/com/example/api/domain/user/service/AuthService.java
@@ -135,7 +135,8 @@ public class AuthService {
     }
 
     @Transactional
-    public TokenResponseDto createNewAccessToken(String refreshToken) {
+    public TokenResponseDto createNewAccessToken(String refreshToken,
+        HttpServletResponse response) {
         // 요청에 리프레시 토큰이 포함되었는지 검증
         if (refreshToken == null || refreshToken.isEmpty()) {
             throw new IllegalArgumentException("refresh token이 null 또는 빈 문자열로 입력되었습니다.");
@@ -161,6 +162,8 @@ public class AuthService {
 
         // 새로운 액세스 토큰 발급
         String newAccessToken = refreshTokenService.generateNewAccessToken(refreshToken);
+
+        addCookie(response, "accessToken", newAccessToken, 60 * 60);
 
         return new TokenResponseDto(newAccessToken);
     }

--- a/api/src/main/java/com/example/api/domain/user/service/AuthService.java
+++ b/api/src/main/java/com/example/api/domain/user/service/AuthService.java
@@ -5,16 +5,19 @@ import com.example.api.domain.user.dto.request.RefreshTokenRequestDto;
 import com.example.api.domain.user.dto.request.SignupRequestDto;
 import com.example.api.domain.user.dto.response.LoginResponseDto;
 import com.example.api.domain.user.dto.response.SignupResponseDto;
+import com.example.api.domain.user.dto.response.TokenResponseDto;
 import com.example.api.domain.user.entity.RefreshToken;
 import com.example.api.domain.user.entity.User;
 import com.example.api.domain.user.repository.RefreshTokenRepository;
 import com.example.api.domain.user.repository.UserRepository;
+import com.example.api.global.exception.RefreshTokenNotFoundException;
 import com.example.api.global.exception.ResourceNotFoundException;
 import com.example.api.global.security.jwt.JwtTokenProvider;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -27,9 +30,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AuthService {
 
@@ -69,10 +71,10 @@ public class AuthService {
         }
 
         Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(
-                        requestDto.getUsername(),
-                        requestDto.getPassword()
-                )
+            new UsernamePasswordAuthenticationToken(
+                requestDto.getUsername(),
+                requestDto.getPassword()
+            )
         );
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
@@ -82,7 +84,7 @@ public class AuthService {
         String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
 
         User user = userRepository.findByUsername(requestDto.getUsername())
-                .orElseThrow(() -> new ResourceNotFoundException("일치하는 사용자를 찾을 수 없습니다."));
+            .orElseThrow(() -> new ResourceNotFoundException("일치하는 사용자를 찾을 수 없습니다."));
 
         refreshTokenService.saveOrUpdateRefreshToken(user, refreshToken);
 
@@ -91,8 +93,9 @@ public class AuthService {
         return LoginResponseDto.from(user, accessToken, refreshToken);
     }
 
-    private void addCookie(HttpServletResponse response, String username, String value, int maxAge) {
-        Cookie cookie = new Cookie(username, value);
+    private void addCookie(HttpServletResponse response, String token, String value,
+        int maxAge) {
+        Cookie cookie = new Cookie(token, value);
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         cookie.setPath("/");
@@ -114,21 +117,52 @@ public class AuthService {
             throw new ExpiredJwtException(null, null, "refresh token이 만료되었습니다.");
         }
 
-        // 리프레시 토큰이 유효한지(위조되지 않았는지) 검증
+        // 리프레시 토큰이 유효한지, 위조되지 않았는지 검증
         if (!jwtTokenProvider.validateToken(refreshToken)) {
             throw new JwtException("refresh token이 위조되었거나 유효하지 않습니다.");
         }
 
-        // DB에 해당 리프레시 토큰이 존재하는지 검증
-        Optional<RefreshToken> storedRefreshToken = refreshTokenRepository.findByToken(
-                refreshToken);
+        // 리프레시 토큰 유효성 검사 (DB에 저장한 리프레시 토큰과 비교)
+        Optional<RefreshToken> storedRefreshToken = refreshTokenService.getRefreshToken(
+            refreshToken);
 
         if (storedRefreshToken.isEmpty()) {
-            throw new ResourceNotFoundException("일치하는 refresh token을 찾을 수 없습니다.");
+            throw new RefreshTokenNotFoundException("일치하는 refresh token을 찾을 수 없습니다.");
         }
 
         // 리프레시 토큰에 대한 유효성이 검증되었으면 DB에서 해당 리프레시 토큰을 삭제
         refreshTokenRepository.delete(storedRefreshToken.get());
+    }
+
+    @Transactional
+    public TokenResponseDto createNewAccessToken(String refreshToken) {
+        // 요청에 리프레시 토큰이 포함되었는지 검증
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            throw new IllegalArgumentException("refresh token이 null 또는 빈 문자열로 입력되었습니다.");
+        }
+
+        // 리프레시 토큰이 만료되었는지 검증
+        if (jwtTokenProvider.validateTokenExpired(refreshToken)) {
+            throw new ExpiredJwtException(null, null, "refresh token이 만료되었습니다.");
+        }
+
+        // 리프레시 토큰이 유효한지, 위조되지 않았는지 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new JwtException("refresh token이 위조되었거나 유효하지 않습니다.");
+        }
+
+        // 리프레시 토큰 유효성 검사 (DB에 저장한 리프레시 토큰과 비교)
+        Optional<RefreshToken> storedRefreshToken = refreshTokenService.getRefreshToken(
+            refreshToken);
+
+        if (storedRefreshToken.isEmpty()) {
+            throw new RefreshTokenNotFoundException("일치하는 refresh token을 찾을 수 없습니다.");
+        }
+
+        // 새로운 액세스 토큰 발급
+        String newAccessToken = refreshTokenService.generateNewAccessToken(refreshToken);
+
+        return new TokenResponseDto(newAccessToken);
     }
 
     public boolean checkUsername(String username) {

--- a/api/src/main/java/com/example/api/domain/user/service/RefreshTokenService.java
+++ b/api/src/main/java/com/example/api/domain/user/service/RefreshTokenService.java
@@ -3,8 +3,13 @@ package com.example.api.domain.user.service;
 import com.example.api.domain.user.entity.RefreshToken;
 import com.example.api.domain.user.entity.User;
 import com.example.api.domain.user.repository.RefreshTokenRepository;
+import com.example.api.global.security.jwt.JwtTokenProvider;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class RefreshTokenService {
 
     private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
 
     @Transactional
     public void saveOrUpdateRefreshToken(User user, String refreshToken) {
@@ -24,5 +31,20 @@ public class RefreshTokenService {
             RefreshToken newToken = new RefreshToken(null, user, refreshToken);
             refreshTokenRepository.save(newToken);
         }
+    }
+
+    public Optional<RefreshToken> getRefreshToken(String token) {
+        return refreshTokenRepository.findByToken(token);
+    }
+
+    public String generateNewAccessToken(String refreshToken) {
+        // 리프레시 토큰에서 사용자 정보 가져오기
+        String username = jwtTokenProvider.getUsername(refreshToken);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+        // 새로운 액세스 토큰 생성
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null,
+            userDetails.getAuthorities());
+        return jwtTokenProvider.createAccessToken(authentication);
     }
 }

--- a/api/src/main/java/com/example/api/global/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/example/api/global/exception/GlobalExceptionHandler.java
@@ -98,6 +98,14 @@ public class GlobalExceptionHandler {
             .body(ApiResponse.error(ex.getMessage(), "UNAUTHORIZED"));
     }
 
+    @ExceptionHandler(RefreshTokenNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTokenMatch(
+        RefreshTokenNotFoundException ex) {
+        return ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(ApiResponse.error(ex.getMessage(), "UNAUTHORIZED"));
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(
         IllegalArgumentException ex) {

--- a/api/src/main/java/com/example/api/global/exception/RefreshTokenNotFoundException.java
+++ b/api/src/main/java/com/example/api/global/exception/RefreshTokenNotFoundException.java
@@ -1,0 +1,12 @@
+package com.example.api.global.exception;
+
+public class RefreshTokenNotFoundException extends RuntimeException {
+
+    public RefreshTokenNotFoundException(String message) {
+        super(message);
+    }
+
+    public RefreshTokenNotFoundException() {
+        super("일치하는 토큰을 찾을 수 없습니다.");
+    }
+}

--- a/api/src/main/java/com/example/api/global/security/jwt/JwtTokenProvider.java
+++ b/api/src/main/java/com/example/api/global/security/jwt/JwtTokenProvider.java
@@ -1,21 +1,23 @@
 package com.example.api.global.security.jwt;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import java.util.Base64;
+import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
-
-import java.util.Base64;
-import java.util.Date;
 
 @Component
 public class JwtTokenProvider {
 
     private final long accessTokenValidity = 1000L * 60 * 60; // 1시간
     private final long refreshTokenValidity = 1000L * 60 * 60 * 24 * 7; // 7일
-    //    private final long tokenValidityInMilliseconds = 1000L * 60 * 60 * 10; // 1시간
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -33,11 +35,11 @@ public class JwtTokenProvider {
         Date validity = new Date(now.getTime() + accessTokenValidity);
 
         return Jwts.builder()
-                .setClaims(claims)
-                .setIssuedAt(now)
-                .setExpiration(validity)
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS256)
-                .compact();
+            .setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(validity)
+            .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS256)
+            .compact();
     }
 
     public String createRefreshToken(Authentication authentication) {
@@ -48,35 +50,35 @@ public class JwtTokenProvider {
         Date validity = new Date(now.getTime() + refreshTokenValidity);
 
         return Jwts.builder()
-                .setClaims(claims)
-                .setIssuedAt(now)
-                .setExpiration(validity)
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS256)
-                .compact();
+            .setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(validity)
+            .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS256)
+            .compact();
     }
 
     // 토큰이 위조 여부, 유효한지 여부 검증
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder()
-                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                    .build()
-                    .parseClaimsJws(token);
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseClaimsJws(token);
             return true;
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
     }
 
-    // 토큰 만료 여부를 검증
+    //    // 토큰 만료 여부를 검증
     public boolean validateTokenExpired(String token) {
         try {
             Date expirationDate = Jwts.parserBuilder()
-                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody()
-                    .getExpiration();
+                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
             return expirationDate.before(new Date());
         } catch (ExpiredJwtException e) {
             return true; // 만료됨
@@ -87,10 +89,10 @@ public class JwtTokenProvider {
 
     public String getUsername(String token) {
         return Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                .build()
-                .parseClaimsJws(token)
-                .getBody()
-                .getSubject();
+            .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
+            .build()
+            .parseClaimsJws(token)
+            .getBody()
+            .getSubject();
     }
 }


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- BD-169


## 📌 작업 내용 

- commit 1
    - `AuthController` 수정 : /api/auth/reissuance 요청에 대한 처리 (@RequestHeader 활용해서 요청 헤더에서 Refresh token 받아오기)
    - `AuthService` 수정 : refresh token에 대한 유효성 검증을 진행한 후, 통과했으면 새로운 액세스 토큰 발급하는 로직 구현
    - `RefreshTokenService` 수정 : DB로부터 refresh token을 조회하는 메서드, refresh token을 바탕으로 액세스 토큰을 발급하는 메서드 추가
    - `JwtTokenProvider` 수정 :
    - `JwtAuthenticationFilter` 수정 : 해당 필터에서는 access token만 받도록 수정, access token 만료 여부 확인하는 로직 추가
    - `GlobalExceptionHandler` 수정 : RefreshTokenNotFoundException에 대한 전역 예외 처리 추가
    - `RefreshTokenNotFoundException` 생성 및 구현 : DB에서 일치하는 토큰이 존재하는지 체크하는 커스텀 예외 구현
    - `TokenResponseDto` 생성 및 구현 : 액세스 토큰을 응답하도록 구현

- commit 2
    - `AuthController` 수정 : 헤더 쿠키로 응답하도록 수정


## ✅ 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트


## 🗂 참고 사항