### PR TITLE
[BD-176] refactor: back 리프레시 토큰 요청 방식 수정

### DIFF
--- a/api/src/main/java/com/example/api/domain/user/controller/AuthController.java
+++ b/api/src/main/java/com/example/api/domain/user/controller/AuthController.java
@@ -17,7 +17,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -79,9 +78,9 @@ public class AuthController {
     // 액세스 토큰 재발급
     @PostMapping("/auth/reissuance")
     public ResponseEntity<ApiResponse<TokenResponseDto>> createNewAccessToken(
-        @RequestHeader("Refresh") String refreshToken, HttpServletResponse response) {
+        HttpServletRequest request) {
         return ResponseEntity.ok(
             ApiResponse.ok("access token이 재발급되었습니다.", "OK",
-                authService.createNewAccessToken(refreshToken, response)));
+                authService.createNewAccessToken(request)));
     }
 }

--- a/api/src/main/java/com/example/api/domain/user/controller/AuthController.java
+++ b/api/src/main/java/com/example/api/domain/user/controller/AuthController.java
@@ -2,13 +2,13 @@ package com.example.api.domain.user.controller;
 
 import com.example.api.domain.bucket.dto.response.UsernameCheckResponseDto;
 import com.example.api.domain.user.dto.request.LoginRequestDto;
-import com.example.api.domain.user.dto.request.RefreshTokenRequestDto;
 import com.example.api.domain.user.dto.request.SignupRequestDto;
 import com.example.api.domain.user.dto.response.LoginResponseDto;
 import com.example.api.domain.user.dto.response.SignupResponseDto;
 import com.example.api.domain.user.dto.response.TokenResponseDto;
 import com.example.api.domain.user.service.AuthService;
 import com.example.api.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -54,8 +54,7 @@ public class AuthController {
     }
 
     @PostMapping("/auth/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(
-        @RequestBody RefreshTokenRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest requestDto) {
 
         authService.logout(requestDto);
 

--- a/api/src/main/java/com/example/api/domain/user/service/AuthService.java
+++ b/api/src/main/java/com/example/api/domain/user/service/AuthService.java
@@ -1,7 +1,6 @@
 package com.example.api.domain.user.service;
 
 import com.example.api.domain.user.dto.request.LoginRequestDto;
-import com.example.api.domain.user.dto.request.RefreshTokenRequestDto;
 import com.example.api.domain.user.dto.request.SignupRequestDto;
 import com.example.api.domain.user.dto.response.LoginResponseDto;
 import com.example.api.domain.user.dto.response.SignupResponseDto;
@@ -16,7 +15,9 @@ import com.example.api.global.security.jwt.JwtTokenProvider;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -104,8 +105,17 @@ public class AuthService {
     }
 
     @Transactional
-    public void logout(RefreshTokenRequestDto requestDto) {
-        String refreshToken = requestDto.getRefreshToken();
+    public void logout(HttpServletRequest requestDto) {
+        Cookie[] cookies = requestDto.getCookies();
+        if (cookies == null) {
+            throw new IllegalArgumentException("refresh token이 없습니다.");
+        }
+
+        String refreshToken = Arrays.stream(cookies)
+            .filter(cookie -> "refreshToken".equals(cookie.getName()))
+            .map(Cookie::getValue)
+            .findFirst()
+            .orElse(null);
 
         // 요청에 리프레시 토큰이 포함되었는지 검증
         if (refreshToken == null || refreshToken.isEmpty()) {


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- BD-176


## 📌 작업 내용

- commit 1
    - `AuthController` , `AuthService`수정 : 로그아웃 요청 시 헤더 쿠키로 refresh token을 전달받도록 수정

- commit 2
    - `AuthController` , `AuthService`수정 : 액세스 토큰 재발급 요청 시 헤더 쿠키로 refresh token을 전달받도록 수정


## ✅ 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트


## 🗂 참고 사항