### PR TITLE
[BD-178] refactor: back 사용자 아이디 예외 처리 리팩토링

### DIFF
--- a/api/src/main/java/com/example/api/domain/user/service/AuthService.java
+++ b/api/src/main/java/com/example/api/domain/user/service/AuthService.java
@@ -27,6 +27,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -61,7 +62,7 @@ public class AuthService {
     @Transactional
     public LoginResponseDto login(LoginRequestDto requestDto, HttpServletResponse response) {
         if (!userRepository.existsByUsername(requestDto.getUsername())) {
-            throw new ResourceNotFoundException("일치하는 아이디를 찾을 수 없습니다.");
+            throw new UsernameNotFoundException("일치하는 아이디를 찾을 수 없습니다.");
         }
 
         UserDetails userDetails = userDetailsService.loadUserByUsername(requestDto.getUsername());

--- a/api/src/main/java/com/example/api/global/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/example/api/global/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -63,6 +64,14 @@ public class GlobalExceptionHandler {
                 "입력값 검증에 실패했습니다.",
                 "INVALID_INPUT"
             ));
+    }
+
+    @ExceptionHandler(UsernameNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUsernameNotFoundException(
+        UsernameNotFoundException ex) {
+        return ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(ApiResponse.error(ex.getMessage(), "UNAUTHORIZED"));
     }
 
     @ExceptionHandler(BadCredentialsException.class)


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- BD-178


## 📌 작업 내용

- `AuthService` 수정 : 사용자가 입력한 아이디에 대해 DB에 일치하는 데이터가 없을 때 ResourceNotFoundException → UsernameNotFoundException을 발생시키도록 수정
- `GlobalExceptionHandler` 수정 : UsernameNotFoundException에 대한 전역 예외 처리 (401 Unauthorized)


## ✅ 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트


## 🗂 참고 사항